### PR TITLE
Perf hacking 1 - starting with cilium/ebpf scaffold

### DIFF
--- a/code/perf_hacking/Makefile
+++ b/code/perf_hacking/Makefile
@@ -1,0 +1,8 @@
+all: bpfperf
+
+bpfperf: main.go
+	go build -o bpfperf ./main.go
+
+.PHONY: clean
+clean:
+	rm -rf bpfperf

--- a/code/perf_hacking/go.mod
+++ b/code/perf_hacking/go.mod
@@ -1,0 +1,8 @@
+module github.com/Cropsey/lysefgt/code/perf_hacking
+
+go 1.20
+
+require (
+	github.com/cilium/ebpf v0.10.0
+	golang.org/x/sys v0.8.0
+)

--- a/code/perf_hacking/go.sum
+++ b/code/perf_hacking/go.sum
@@ -1,0 +1,9 @@
+github.com/cilium/ebpf v0.10.0 h1:nk5HPMeoBXtOzbkZBWym+ZWq1GIiHUsBFXxwewXAHLQ=
+github.com/cilium/ebpf v0.10.0/go.mod h1:DPiVdY/kT534dgc9ERmvP8mWA+9gvwgKfRvk4nNWnoE=
+github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/code/perf_hacking/main.go
+++ b/code/perf_hacking/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/rlimit"
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("Expected: ./%s <PID>\n", os.Args[0])
+	}
+	pid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		log.Fatalf("Failed to parse pid from '%s': %v", os.Args[1], err)
+	}
+
+	// Subscribe to signals for terminating the program.
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
+
+	// Allow the current process to lock memory for eBPF resources.
+	if err := rlimit.RemoveMemlock(); err != nil {
+		log.Fatalf("Failed to update rlimit: %v", err)
+	}
+
+	// Create a perf event array for the kernel to write perf records to.
+	// These records will be read by userspace below.
+	events, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type: ebpf.PerfEventArray,
+		Name: "my_perf_array",
+	})
+	if err != nil {
+		log.Fatalf("Creating perf event array: %s", err)
+	}
+	defer events.Close()
+
+	// Open a perf reader from userspace into the perf event array
+	// created earlier.
+	rd, err := perf.NewReader(events, os.Getpagesize())
+	if err != nil {
+		log.Fatalf("Creating event reader: %s", err)
+	}
+	defer rd.Close()
+
+	// Close the reader when the process receives a signal, which will exit
+	// the read loop.
+	go func() {
+		<-stopper
+		rd.Close()
+	}()
+
+	// Metadata for the eBPF program used in this example.
+	var progSpec = &ebpf.ProgramSpec{
+		Name:    "my_perf_event_prog", // non-unique name, will appear in `bpftool prog list` while attached
+		Type:    ebpf.PerfEvent,       // only PerfEvent programs can be attached to perf events
+		License: "GPL",                // license must be GPL for calling kernel helpers like perf_event_output
+	}
+
+	// Minimal program that writes the static value '123' to the perf ring on
+	// each event. Note that this program refers to the file descriptor of
+	// the perf event array created above, which needs to be created prior to the
+	// program being verified by and inserted into the kernel.
+	progSpec.Instructions = asm.Instructions{
+		// store the integer 123 at FP[-8]
+		asm.Mov.Imm(asm.R2, 123),
+		asm.StoreMem(asm.RFP, -8, asm.R2, asm.Word),
+
+		// load registers with arguments for call of FnPerfEventOutput
+		asm.LoadMapPtr(asm.R2, events.FD()), // file descriptor of the perf event array
+		asm.LoadImm(asm.R3, 0xffffffff, asm.DWord),
+		asm.Mov.Reg(asm.R4, asm.RFP),
+		asm.Add.Imm(asm.R4, -8),
+		asm.Mov.Imm(asm.R5, 4),
+
+		// call FnPerfEventOutput, an eBPF kernel helper
+		asm.FnPerfEventOutput.Call(),
+
+		// set exit code to 0
+		asm.Mov.Imm(asm.R0, 0),
+		asm.Return(),
+	}
+
+	// Instantiate and insert the program into the kernel.
+	prog, err := ebpf.NewProgram(progSpec)
+	if err != nil {
+		log.Fatalf("Creating ebpf program: %s", err)
+	}
+	defer prog.Close()
+	log.Println("Waiting for events..")
+
+	ev, err := unix.PerfEventOpen(
+		&unix.PerfEventAttr{
+			Type:        unix.PERF_TYPE_SOFTWARE,
+			Config:      unix.PERF_COUNT_SW_CPU_CLOCK,
+			Sample_type: unix.PERF_SAMPLE_RAW,
+			Sample:      1,
+			Wakeup:      1,
+		},
+		pid,
+		0,
+		-1,
+		unix.PERF_FLAG_FD_CLOEXEC,
+	)
+	if err != nil {
+		log.Fatalf("Failed to create the perf event: %v", err)
+	}
+	defer func() {
+		if err := unix.Close(ev); err != nil {
+			log.Fatalf("Failed to close perf event: %v", err)
+		}
+	}()
+
+	// attach ebpf to perf event
+	if err := unix.IoctlSetInt(ev, unix.PERF_EVENT_IOC_SET_BPF, prog.FD()); err != nil {
+		log.Fatalf("Failed to attach eBPF program to perf event: %v", err)
+	}
+
+	// start perf event
+	if err := unix.IoctlSetInt(ev, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+		log.Fatalf("Failed to enable perf event: %v", err)
+	}
+
+	defer func() {
+		if err := unix.IoctlSetInt(ev, unix.PERF_EVENT_IOC_DISABLE, 0); err != nil {
+			log.Fatalf("Failed to disable perf event: %v", err)
+		}
+	}()
+
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, perf.ErrClosed) {
+				log.Println("Received signal, exiting..")
+				return
+			}
+			log.Printf("Reading from reader: %s", err)
+			continue
+		}
+
+		log.Println("Record:", record)
+	}
+}


### PR DESCRIPTION
This PR converts discussion from https://github.com/cilium/ebpf/discussions/548 exactly as outlined there + `Makefile` and `go.mod`. These are our first baby steps towards an eBPF profiler.

In this version, the "profiler" does a couple of things that the future versions build up on:
1. Create an eBPF map of type [`BPF_MAP_TYPE_PERCPU_ARRAY`](https://docs.kernel.org/bpf/map_array.html#bpf-map-type-array-and-bpf-map-type-percpu-array) for kernel and userspace to exchange events
2. Create an eBPF program of type [`BPF_PROG_TYPE_PERF_EVENT`](https://docs.kernel.org/bpf/libbpf/program_types.html#program-types-and-elf-sections) which is loaded to the kernel to be executed on a perf event. The program is basic and sends always just `123` as the content of the event. It mainly serves the single purpose of demonstrating how to connect the parts together.
3. Call [`perf_event_open` syscall](https://man7.org/linux/man-pages/man2/perf_event_open.2.html) to instruct the kernel to periodically profile a certain process on any CPU.
4. Attach the eBPF program to the perf event and enable the perf event
5. In a loop, read on the eBPF map for any events from the kernel

Example output:
```
pid[47794]
  RECORD
  ---------
  {1 [123 0 0 0] 0}
```