### PR TITLE
Perf hacking 3 - ELF enhanced stack traces

### DIFF
--- a/code/perf_hacking/main.go
+++ b/code/perf_hacking/main.go
@@ -78,6 +78,7 @@ func main() {
 		}
 	}()
 
+	elf := newElf(pid)
 	var event bpfEvent
 	for {
 		record, err := rd.Read()
@@ -94,9 +95,9 @@ func main() {
 		}
 
 		fmt.Printf("bin[%v] pid[%v]\n", event.taskComm(), pid)
-		ustack := stack(event.UserStack)
-		fmt.Println("  ADDRESS")
-		fmt.Println("  ---------")
+		ustack := elf.humanReadableStack(event.UserStack)
+		fmt.Println("  ADDRESS    PC         SYMBOL                            ")
+		fmt.Println("  ---------  ---------  --------------------------------- ")
 		for _, l := range ustack {
 			fmt.Println(" ", l)
 		}

--- a/code/perf_hacking/parser.go
+++ b/code/perf_hacking/parser.go
@@ -1,22 +1,66 @@
 package main
 
-import "fmt"
+import (
+	"debug/elf"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+)
 
 type stackPos struct {
-	addr uint64
+	addr   uint64
+	pc     uint64
+	symbol string
 }
 
 func (sp stackPos) String() string {
-	return fmt.Sprintf("0x%0.8x", sp.addr)
+	return fmt.Sprintf("0x%0.8x 0x%0.8x %-33v", sp.addr, sp.pc, sp.symbol+"()")
 }
 
-func stack(stack [100]uint64) []stackPos {
+type elfHelper struct {
+	symbols []elf.Symbol
+	elfFile *elf.File
+}
+
+func newElf(pid int) elfHelper {
+	binPath, err := os.Readlink(fmt.Sprintf("/proc/%v/exe", pid))
+	if err != nil {
+		log.Fatalf("Failed to read binpath from pid %v: %v", err)
+	}
+	f, err := os.Open(binPath)
+	if err != nil {
+		log.Fatalf("failed to open file %q: %v\n", binPath, err)
+	}
+	ef, err := elf.NewFile(f)
+	if err != nil {
+		log.Fatalf("failed to elf open file %q: %v\n", binPath, err)
+	}
+	e := elfHelper{}
+	e.symbols, err = ef.Symbols()
+	if err != nil {
+		log.Fatalf("failed to get elf symbols for file %q: %v\n", binPath, err)
+	}
+	sort.Slice(e.symbols, func(i, j int) bool { return e.symbols[i].Value < e.symbols[j].Value })
+	e.elfFile = ef
+	return e
+}
+
+func (e elfHelper) humanReadableStack(stack [100]uint64) []stackPos {
 	st := []stackPos{}
 	for _, addr := range stack {
 		if addr == 0 {
 			break
 		}
-		st = append(st, stackPos{addr: addr})
+		prev := stackPos{addr: addr}
+		for _, s := range e.symbols {
+			if addr < s.Value {
+				st = append(st, prev)
+				break
+			}
+			prev.symbol = s.Name
+			prev.pc = s.Value
+		}
 	}
 	return st
 }


### PR DESCRIPTION
This PR improves https://github.com/Cropsey/lysefgt/pull/4 a little further.

...

Example output:
```
bin[testbin] pid[47794]
  ADDRESS    PC         SYMBOL
  ---------  ---------  ---------------------------------
  0x00457fc3 0x00457fa0 runtime.futex.abi0()
  0x004098e7 0x00409860 runtime.notesleep()
  0x00433bcc 0x00433b40 runtime.stopm()
  0x0043541c 0x00434960 runtime.findRunnable()
  0x00436251 0x004361a0 runtime.schedule()
  0x0043676d 0x00436640 runtime.park_m()
  0x00455d23 0x00455ce0 runtime.mcall()
  0x00454ef5 0x00454dc0 time.Sleep()
  0x0045a785 0x0045a760 main.easyToFindFunctionName()
  0x0045a7f7 0x0045a7e0 main.main()
  0x0042fbe7 0x0042f9e0 runtime.main()
  0x00456141 0x00456140 runtime.goexit.abi0()
```