### PR TITLE
Profiler 2 - getting stack traces

### DIFF
--- a/code/profiler/Makefile
+++ b/code/profiler/Makefile
@@ -1,8 +1,12 @@
 all: profiler
 
-profiler: main.go
-	go build -o profiler ./main.go
+profiler: main.go parser.go bpf_bpfel_x86.o
+	go build -o profiler ./main.go ./parser.go ./bpf_bpfel_x86.go
+
+# compile eBPF program using cillium/ebpf library
+bpf_bpfel_x86.o: main.go perf.c
+	CPATH=../headers go generate ./...
 
 .PHONY: clean
 clean:
-	rm -rf profiler
+	rm -rf profiler bpf_bpfel_x86.go bpf_bpfel_x86.o

--- a/code/profiler/main.go
+++ b/code/profiler/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"flag"
 	"fmt"
@@ -8,11 +10,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/perf"
 	"golang.org/x/sys/unix"
 )
+
+// Use cilium/ebpf package to generate eBPF scaffold for programs and maps
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags "-O2 -g -Wall -Werror" -target native -type event bpf perf.c -- -I../headers
 
 // main is an entrypoint to the profiler
 func main() {
@@ -24,61 +27,20 @@ func main() {
 	// Print errors where they belong
 	log.SetOutput(os.Stderr)
 
-	// Create a perf event array for the kernel to write perf records to.
-	// These records will be read by userspace below.
-	events, err := ebpf.NewMap(&ebpf.MapSpec{
-		Type: ebpf.PerfEventArray,
-		Name: "my_perf_array",
-	})
-	if err != nil {
-		log.Fatalf("Creating perf event array: %s", err)
+	// Leverage cilium/ebpf generated scaffold
+	objs := bpfObjects{}
+	if err := loadBpfObjects(&objs, nil); err != nil {
+		log.Fatalf("loading objects: %s", err)
 	}
-	defer events.Close()
+	defer objs.Close()
 
 	// Open a perf reader from userspace into the perf event array created earlier.
-	rd, err := perf.NewReader(events, os.Getpagesize())
+	rd, err := perf.NewReader(objs.Events, os.Getpagesize())
 	if err != nil {
 		log.Fatalf("Creating event reader: %s", err)
 	}
 	defer rd.Close()
 
-	// Metadata for the eBPF program used in this example.
-	var progSpec = &ebpf.ProgramSpec{
-		Name:    "my_perf_event_prog", // non-unique name, will appear in `bpftool prog list` while attached
-		Type:    ebpf.PerfEvent,       // only PerfEvent programs can be attached to perf events
-		License: "GPL",                // license must be GPL for calling kernel helpers like perf_event_output
-	}
-
-	// Minimal program that writes the static value '123' to the perf ring on
-	// each event. Note that this program refers to the file descriptor of
-	// the perf event array created above, which needs to be created prior to the
-	// program being verified by and inserted into the kernel.
-	progSpec.Instructions = asm.Instructions{
-		// store the integer 123 at FP[-8]
-		asm.Mov.Imm(asm.R2, 123),
-		asm.StoreMem(asm.RFP, -8, asm.R2, asm.Word),
-
-		// load registers with arguments for call of FnPerfEventOutput
-		asm.LoadMapPtr(asm.R2, events.FD()), // file descriptor of the perf event array
-		asm.LoadImm(asm.R3, 0xffffffff, asm.DWord),
-		asm.Mov.Reg(asm.R4, asm.RFP),
-		asm.Add.Imm(asm.R4, -8),
-		asm.Mov.Imm(asm.R5, 4),
-
-		// call FnPerfEventOutput, an eBPF kernel helper
-		asm.FnPerfEventOutput.Call(),
-
-		// set exit code to 0
-		asm.Mov.Imm(asm.R0, 0),
-		asm.Return(),
-	}
-
-	// Instantiate and insert the program into the kernel.
-	prog, err := ebpf.NewProgram(progSpec)
-	if err != nil {
-		log.Fatalf("Creating ebpf program: %s", err)
-	}
-	defer prog.Close()
 	log.Println("Waiting for events..")
 
 	anyCPU := -1      // Sample application on any CPU
@@ -107,7 +69,7 @@ func main() {
 	}()
 
 	// Tell kernel to attach eBPF program to the perf event fd
-	if err := unix.IoctlSetInt(perfEventFD, unix.PERF_EVENT_IOC_SET_BPF, prog.FD()); err != nil {
+	if err := unix.IoctlSetInt(perfEventFD, unix.PERF_EVENT_IOC_SET_BPF, objs.bpfPrograms.PerfEventStacktrace.FD()); err != nil {
 		log.Fatalf("Failed to attach eBPF program to perf event: %v", err)
 	}
 
@@ -122,6 +84,9 @@ func main() {
 		}
 	}()
 
+	// Forward declarations for the loop variables
+	var event bpfEvent
+
 	// Loop forever and process stack traces
 	for {
 		record, err := rd.Read()
@@ -134,10 +99,20 @@ func main() {
 			continue
 		}
 
-		fmt.Printf("pid[%v]\n", pid)
-		fmt.Println("  RECORD")
+		// Read eBPF binary data into go native structure, the ABI compatibility is ensured by cilium/ebpf
+		if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &event); err != nil {
+			log.Printf("parsing perf event failed: %s", err)
+		}
+
+		// Get the stack trace from eBPF with raw addresses
+		ustack := stack(event.UserStack)
+		// Print each event
+		fmt.Printf("bin[%v] pid[%v]\n", event.taskComm(), pid)
+		fmt.Println("  ADDRESS")
 		fmt.Println("  ---------")
-		fmt.Println(" ", record)
+		for _, l := range ustack {
+			fmt.Println(" ", l)
+		}
 		fmt.Println()
 	}
 }

--- a/code/profiler/parser.go
+++ b/code/profiler/parser.go
@@ -1,0 +1,35 @@
+package main
+
+import "fmt"
+
+// To keep track of particular stack trace position
+type stackPos struct {
+	addr uint64 // Exact address from the stack at the time of perf event sample
+}
+
+// Prettier print for stackPos
+func (sp stackPos) String() string {
+	return fmt.Sprintf("0x%0.8x", sp.addr)
+}
+
+// Convert the address stack trace to human readable stack trace
+func stack(stack [10]uint64) []stackPos {
+	st := []stackPos{}
+	// For each address in the stack trace
+	for _, addr := range stack {
+		if addr == 0 {
+			break
+		}
+		st = append(st, stackPos{addr: addr})
+	}
+	return st
+}
+
+// Convert 0 terminated C string to Go string
+func (event bpfEvent) taskComm() string {
+	bs := make([]byte, 0, len(event.Name))
+	for i := 0; i < len(event.Name) && event.Name[i] != 0; i++ {
+		bs = append(bs, byte(event.Name[i]))
+	}
+	return string(bs)
+}

--- a/code/profiler/perf.c
+++ b/code/profiler/perf.c
@@ -1,0 +1,77 @@
+// +build ignore
+
+// Include headers from ebpf/cilium
+#include "common.h"
+#include "bpf_tracing.h"
+
+// License must be present for each eBPF program
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+// Flag to obtain user space stack trace (kernel space stack trace flag is '0')
+enum {
+    BPF_F_USER_STACK        = (1ULL << 8),
+};
+
+// Max size of the stack trace, our traces are fairly small
+#define MAX_STACK_RAWTP 10
+
+// Event we want to send from the kernel eBPF program to the user space
+struct event {
+    u32 pid;                           // Kernel returned PID of the profiled process
+    u32 kern_stack_size;               // Size of the kernel stack trace
+    u32 user_stack_size;               // Size of the user space stack trace
+    u64 kern_stack[MAX_STACK_RAWTP];   // Array to hold the kernel stack trace 
+    u64 user_stack[MAX_STACK_RAWTP];   // Array to hold the user space stack trace
+    char name[16];                     // Binary name, 16 chars is kernel defined (sched.h, TASK_COMM_LEN)
+};
+
+// eBPF map used for sending the events from kernel to user space
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+} events SEC(".maps");
+
+// In order to read the stack data, we need to use eBPF map for safe memory handling
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct event);
+} stackdata_map SEC(".maps");
+
+// Force emitting struct event into the ELF for eBPF program so cilium/ebpf package can generate scaffold for us
+const struct event *unused __attribute__((unused));
+
+// ELF section name for the eBPF program so kernel knows how and where to load it 
+// perf_event is one of the eBPF program types
+// stacktrace is our defined name of the program
+SEC("perf_event/stacktrace")
+int perf_event_stacktrace(struct pt_regs *ctx) {
+    int max_len = MAX_STACK_RAWTP * sizeof(u64);
+
+    // Because stack is limitted to 512 bytes for eBPF programs, larger chunks of memory are allocated in
+    // per-cpu array map. The key is always going to be 0 as we are not using the map for anything but
+    // temporary memory for the stack traces
+    u32 key = 0;
+    struct event *event;
+    event = bpf_map_lookup_elem(&stackdata_map, &key);
+    if (!event) {
+        return 0;
+    }
+
+    // Use eBPF helpers to get PID, kernel comm, and stack traces
+    event->pid = bpf_get_current_pid_tgid();
+    bpf_get_current_comm(event->name, sizeof(event->name));
+    event->kern_stack_size = bpf_get_stack(ctx, event->kern_stack, max_len, 0);
+    event->user_stack_size = bpf_get_stack(ctx, event->user_stack, max_len, BPF_F_USER_STACK);
+
+    // Using eBPF helper to print tracing information for debugging purposes
+    // on older kernels ABI allows passing up to 4 parameters
+    // can be viewed in /sys/kernel/debug/tracing/trace_pipe
+    bpf_printk("sending event: name(%s) kernel_size(%d)/userspace_size(%d)", event->name, event->kern_stack_size, event->user_stack_size);
+
+    // Send the event with stack traces from kernel to user space
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event, sizeof(*event));
+
+    return 0;
+}
+


### PR DESCRIPTION
This PR continues on the groundwork prepared by https://github.com/Cropsey/lysefgt/pull/13. The `profiler` while executing custom eBPF code on perf events, was still not very useful. This version will be slightly more useful as it will at least contain stack traces in the form of a hexadecimal memory address.

1. Convert the eBPF program from assembly to C.
2. Use [`bpf_get_stack()`](https://man.archlinux.org/man/bpf-helpers.7.en#long~51) helper to obtain stack trace in form of hexadecimal memory address.
3. Use [`bpf_get_current_pid_tgid`](https://man.archlinux.org/man/bpf-helpers.7.en#u64~2) to get current PID
4. Use [`bpf_get_current_comm`](https://man.archlinux.org/man/bpf-helpers.7.en#long~10) to get current process [kernel task comm]()

**Example output:**
```
bin[sample_app] pid[47794]
  ADDRESS
  ---------
  0x0047e022
  0x0047e0d7
  0x004324d2
  0x0045a901
```