### PR TITLE
Profiler 3 - ELF enhanced stack traces

### DIFF
--- a/code/profiler/main.go
+++ b/code/profiler/main.go
@@ -84,6 +84,8 @@ func main() {
 		}
 	}()
 
+	// Create ELF parser for the binary running as process with PID
+	elf := newElf(pid)
 	// Forward declarations for the loop variables
 	var event bpfEvent
 
@@ -104,12 +106,12 @@ func main() {
 			log.Printf("parsing perf event failed: %s", err)
 		}
 
-		// Get the stack trace from eBPF with raw addresses
-		ustack := stack(event.UserStack)
+		// Transform the stack trace from eBPF with raw addresses to something more readable
+		ustack := elf.humanReadableStack(event.UserStack)
 		// Print each event
 		fmt.Printf("bin[%v] pid[%v]\n", event.taskComm(), pid)
-		fmt.Println("  ADDRESS")
-		fmt.Println("  ---------")
+		fmt.Println("  ADDRESS    PC         SYMBOL                            ")
+		fmt.Println("  ---------  ---------  --------------------------------- ")
 		for _, l := range ustack {
 			fmt.Println(" ", l)
 		}

--- a/code/profiler/parser.go
+++ b/code/profiler/parser.go
@@ -1,26 +1,76 @@
 package main
 
-import "fmt"
+import (
+	"debug/elf"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+)
 
-// To keep track of particular stack trace position
+// To keep track of particular stack trace position enhanced with human readable metadata
 type stackPos struct {
-	addr uint64 // Exact address from the stack at the time of perf event sample
+	addr   uint64 // Exact address from the stack at the time of perf event sample
+	pc     uint64 // Address of the symbol for the exact address
+	symbol string // Symbol from ELF
 }
 
 // Prettier print for stackPos
 func (sp stackPos) String() string {
-	return fmt.Sprintf("0x%0.8x", sp.addr)
+	return fmt.Sprintf("0x%0.8x 0x%0.8x %-33v", sp.addr, sp.pc, sp.symbol+"()")
+}
+
+// Pre-processed ELF data of the profiled binary
+type elfHelper struct {
+	symbols []elf.Symbol
+	elfFile *elf.File
+}
+
+// Initialize ELF helper
+func newElf(pid int) elfHelper {
+	// Figure out the binary path for the process with PID
+	binPath, err := os.Readlink(fmt.Sprintf("/proc/%v/exe", pid))
+	if err != nil {
+		log.Fatalf("Failed to read binpath from pid %v: %v", err)
+	}
+	f, err := os.Open(binPath)
+	if err != nil {
+		log.Fatalf("failed to open file %q: %v\n", binPath, err)
+	}
+	ef, err := elf.NewFile(f)
+	if err != nil {
+		log.Fatalf("failed to elf open file %q: %v\n", binPath, err)
+	}
+	e := elfHelper{}
+
+	// Get symbols from ELF and sort them by address
+	e.symbols, err = ef.Symbols()
+	if err != nil {
+		log.Fatalf("failed to get elf symbols for file %q: %v\n", binPath, err)
+	}
+	sort.Slice(e.symbols, func(i, j int) bool { return e.symbols[i].Value < e.symbols[j].Value })
+	e.elfFile = ef
+	return e
 }
 
 // Convert the address stack trace to human readable stack trace
-func stack(stack [10]uint64) []stackPos {
+func (e elfHelper) humanReadableStack(stack [10]uint64) []stackPos {
 	st := []stackPos{}
 	// For each address in the stack trace
 	for _, addr := range stack {
 		if addr == 0 {
 			break
 		}
-		st = append(st, stackPos{addr: addr})
+		prev := stackPos{addr: addr}
+		// Find the matching symbol from ELF
+		for _, s := range e.symbols {
+			if addr < s.Value {
+				st = append(st, prev)
+				break
+			}
+			prev.symbol = s.Name
+			prev.pc = s.Value
+		}
 	}
 	return st
 }


### PR DESCRIPTION
This PR improves https://github.com/Cropsey/lysefgt/pull/14 a little further by adding symbols from ELF. A way to add these is by reading and parsing the executable binary and matching the addresses from the stack trace to addresses in the symbol table. In order to find which executable is associated with the PID, we can look at the symlink in `/proc/$PID/exe`.

**Example output:**
```
bin[sample_app] pid[47794]
  ADDRESS    PC         SYMBOL                            
  ---------  ---------  --------------------------------- 
  0x0047e022 0x0047dfc0 main.easyToFindFunctionName()    
  0x0047e0d7 0x0047e0c0 main.main()                      
  0x004324d2 0x004322c0 runtime.main()                   
  0x0045a901 0x0045a900 runtime.goexit.abi0()
```