### PR TITLE
Kubernetes 0 - profiling agent

### DIFF
--- a/code/profiler/Dockerfile
+++ b/code/profiler/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+COPY ./profiler /usr/bin/profiler
+
+CMD [ "/usr/bin/profiler", "-v", "2" ]

--- a/code/profiler/Makefile
+++ b/code/profiler/Makefile
@@ -10,3 +10,12 @@ bpf_bpfel_x86.o: main.go perf.c
 .PHONY: clean
 clean:
 	rm -rf profiler bpf_bpfel_x86.go bpf_bpfel_x86.o
+
+.PHONY: docker-build
+docker-build: profiler
+	docker build . -t registry.kube-system.svc:5000/profiler:latest
+	docker push registry.kube-system.svc:5000/profiler:latest
+
+.PHONY: deploy
+deploy: docker-build
+	kubectl apply -f daemonset.yaml

--- a/code/profiler/daemonset.yaml
+++ b/code/profiler/daemonset.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: profiler
+  name: profiler
+spec:
+  selector:
+    matchLabels:
+      app: profiler
+  template:
+    metadata:
+      labels:
+        app: profiler
+    spec:
+      containers:
+      - image: registry.kube-system.svc:5000/profiler
+        imagePullPolicy: Always
+        name: profiler
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpffs
+      volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpffs

--- a/code/profiler/parser.go
+++ b/code/profiler/parser.go
@@ -25,16 +25,22 @@ func (sp stackPos) String() string {
 	return fmt.Sprintf("0x%0.8x 0x%0.8x %-33v  %v:%v", sp.addr, sp.pc, sp.symbol+"()", sp.file, sp.line)
 }
 
+// Lazily load ELF data for profiled binaries
+type elfHelperMap struct {
+	helpers map[int]elfHelper
+	skip    map[int]bool
+}
+
 // Pre-processed ELF data of the profiled binary
 type elfHelper struct {
 	symbols []elf.Symbol
 	elfFile *elf.File
 }
 
-// Statistics for stack trace symbol counts
+// Statistics for stack trace symbol counts per PID
 type stats struct {
-	count map[string]int
-	meta  map[string]stackPos
+	count map[int]map[string]int
+	meta  map[int]map[string]stackPos
 }
 
 // Helper for sorting symbols from stack trace stats by most frequently occurring
@@ -46,61 +52,110 @@ type sortSymbolCount struct {
 // Initialize stats counters for stack trace symbol counts
 func newStats() *stats {
 	return &stats{
-		count: make(map[string]int),
-		meta:  make(map[string]stackPos),
+		count: make(map[int]map[string]int),
+		meta:  make(map[int]map[string]stackPos),
 	}
 }
 
 // Process stack position by stats counter
-func (a *stats) add(sp stackPos) {
-	a.count[sp.symbol] += 1
-	if _, exists := a.meta[sp.symbol]; !exists {
-		a.meta[sp.symbol] = sp
+func (a *stats) add(pid int, sp stackPos) {
+	if _, ok := a.count[pid]; !ok {
+		a.count[pid] = make(map[string]int)
+		a.meta[pid] = make(map[string]stackPos)
+	}
+	a.count[pid][sp.symbol] += 1
+	if _, exists := a.meta[pid][sp.symbol]; !exists {
+		a.meta[pid][sp.symbol] = sp
 	}
 }
 
 // Print stack trace stats summary
 func (a *stats) summary() {
-	var s []sortSymbolCount
-	for symbol, count := range a.count {
-		s = append(s, sortSymbolCount{symbol: symbol, count: count})
-	}
-	sort.Slice(s, func(i, j int) bool { return s[i].count > s[j].count })
 	fmt.Println()
 	fmt.Println("AGGREGATED PERF EVENT SAMPLES:")
-	fmt.Println("  COUNT  SYMBOL                                 FILE:LINE")
-	fmt.Println("  -----  -------------------------------------  ------------------------------------")
-	for _, sorted := range s {
-		sp := a.meta[sorted.symbol]
-		fmt.Printf("%7d  %-37v  %v:%v\n", sorted.count, sp.symbol+"()", sp.file, sp.line)
+	fmt.Println("  COUNT PID    SYMBOL                                 FILE:LINE")
+	fmt.Println("  ----- ------ -------------------------------------  ------------------------------------")
+	for pid, pidcount := range a.count {
+		var s []sortSymbolCount
+		for symbol, count := range pidcount {
+			s = append(s, sortSymbolCount{symbol: symbol, count: count})
+		}
+		sort.Slice(s, func(i, j int) bool { return s[i].count > s[j].count })
+		for _, sorted := range s {
+			sp := a.meta[pid][sorted.symbol]
+			fmt.Printf("%7d  %6d %-37v  %v:%v\n", sorted.count, pid, sp.symbol+"()", sp.file, sp.line)
+		}
+		fmt.Println()
 	}
 }
 
 // Initialize ELF helper
-func newElf(pid int) elfHelper {
+func newElf(pid int) elfHelperMap {
+	if pid == 0 {
+		log.Printf("lazy loading all-pid ELF helper")
+		return elfHelperMap{
+			helpers: make(map[int]elfHelper),
+			skip:    make(map[int]bool),
+		}
+	} else {
+		log.Printf("pre-loaded ELF helper for PID %v", pid)
+		eh, err := newElfHelperForPid(pid)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return elfHelperMap{
+			helpers: map[int]elfHelper{pid: eh},
+			skip:    make(map[int]bool),
+		}
+	}
+}
+
+// Convert the address stack trace to human readable stack trace if desired by the profiler
+// skips the processes that it can't understand
+func (e elfHelperMap) humanReadableStack(pid int, stack [10]uint64) []stackPos {
+	if e.skip[pid] {
+		return nil
+	}
+	eh, ok := e.helpers[pid]
+	if ok {
+		return eh.humanReadableStack(stack)
+	}
+	eh, err := newElfHelperForPid(pid)
+	if err != nil {
+		log.Printf("lazy ELF helper for pid %v skip: %v", pid, err)
+		e.skip[pid] = true
+		return nil
+	}
+	e.helpers[pid] = eh
+	return eh.humanReadableStack(stack)
+}
+
+// Initialize ELF helper for PID
+func newElfHelperForPid(pid int) (elfHelper, error) {
 	// Figure out the binary path for the process with PID
 	binPath, err := os.Readlink(fmt.Sprintf("/proc/%v/exe", pid))
 	if err != nil {
-		log.Fatalf("Failed to read binpath from pid %v: %v", err)
+		return elfHelper{}, fmt.Errorf("Failed to read binpath from pid %v: %v", pid, err)
 	}
 	f, err := os.Open(binPath)
 	if err != nil {
-		log.Fatalf("failed to open file %q: %v\n", binPath, err)
+		return elfHelper{}, fmt.Errorf("failed to open file %q: %v\n", binPath, err)
 	}
 	ef, err := elf.NewFile(f)
 	if err != nil {
-		log.Fatalf("failed to elf open file %q: %v\n", binPath, err)
+		return elfHelper{}, fmt.Errorf("failed to elf open file %q: %v\n", binPath, err)
 	}
+	// TODO: check if it's Go binary?
 	e := elfHelper{}
 
 	// Get symbols from ELF and sort them by address
 	e.symbols, err = ef.Symbols()
 	if err != nil {
-		log.Fatalf("failed to get elf symbols for file %q: %v\n", binPath, err)
+		return elfHelper{}, fmt.Errorf("failed to get elf symbols for file %q: %v\n", binPath, err)
 	}
 	sort.Slice(e.symbols, func(i, j int) bool { return e.symbols[i].Value < e.symbols[j].Value })
 	e.elfFile = ef
-	return e
+	return e, nil
 }
 
 // Convert the address stack trace to human readable stack trace


### PR DESCRIPTION
This is the beginning of a transformation. The profiler from https://github.com/Cropsey/lysefgt/pull/17 was capable of profiling a single process and required `-pid` to be non-zero. With these changes, the profiler supports `-pid=0` and takes this as an instruction to profile every process on each CPU.

There are also Kubernetes manifests ready to deploy to a cluster.