### PR TITLE
Kubernetes 1 - unlock memory

### DIFF
--- a/code/profiler/main.go
+++ b/code/profiler/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/rlimit"
 	"golang.org/x/sys/unix"
 )
 
@@ -44,6 +45,11 @@ func main() {
 
 	// Print errors where they belong
 	log.SetOutput(os.Stderr)
+
+	// Allow the current process to lock memory for eBPF resources
+	if err := rlimit.RemoveMemlock(); err != nil {
+		log.Fatalf("Failed to update rlimit: %v", err)
+	}
 
 	// Leverage cilium/ebpf generated scaffold
 	objs := bpfObjects{}


### PR DESCRIPTION
`RLIMIT_MEMLOCK` is a parameter used in [Linux](https://man7.org/linux/man-pages/man2/getrlimit.2.html) to limit the amount of physical memory that any one user process may lock into RAM.

The memory-locking capability is useful for time-sensitive or real-time applications that cannot tolerate the delays of swapping memory contents to and from the disk. Locking memory ensures that the data the application needs is always readily available in RAM, avoiding potential performance penalties due to page faults. The eBPF programs and eBPF maps leverage this capability for performance reasons and may need a good amount of locked memory.