### PR TITLE
Kubernetes 2 - PIDs from host

### DIFF
--- a/code/profiler/daemonset.yaml
+++ b/code/profiler/daemonset.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: profiler
     spec:
+      hostPID: true
       containers:
       - image: registry.kube-system.svc:5000/profiler
         imagePullPolicy: Always


### PR DESCRIPTION
A fairly simple change to allow profiler to understand PIDs sent back from kernel, enabling [`hostPID` on the `DaemonSet`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hosts-namespaces)