### PR TITLE
Kubernetes 3 - run for proc

### DIFF
--- a/code/profiler/Dockerfile
+++ b/code/profiler/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine
 
 COPY ./profiler /usr/bin/profiler
 
-CMD [ "/usr/bin/profiler", "-v", "2" ]
+CMD [ "/usr/bin/profiler", "-v", "2", "-with-containerd", "true" ]

--- a/code/profiler/daemonset.yaml
+++ b/code/profiler/daemonset.yaml
@@ -24,7 +24,12 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpffs
+        - mountPath: /run
+          name: run
       volumes:
       - hostPath:
           path: /sys/fs/bpf
         name: bpffs
+      - hostPath:
+          path: /run
+        name: run

--- a/code/profiler/main.go
+++ b/code/profiler/main.go
@@ -41,6 +41,7 @@ func main() {
 	var verbose int
 	flag.IntVar(&pid, "pid", 0, "PID of the profiled process, when 0 it will try to profile all processes it has ability to do so")
 	flag.IntVar(&verbose, "v", 0, "Verbosity of perf event logs, 0 prints only aggregate, 1 prints each perf event record")
+	flag.BoolVar(&withContainerd, "with-containerd", false, "Flag controlling how to determine the binary a profiled process is executing. When set to 'true' it will figure out from cgroup where the binary is stored in the container fs instead of using just /proc/{pid}/exe")
 	flag.Parse()
 
 	// Print errors where they belong


### PR DESCRIPTION
The profiler's main interest should be containerized applications deployed to a particular Kubernetes cluster. The paths to process binary executables from `/proc/${PID}/exe` are not aware of Kubernetes, CRI and OverlayFS. But this profiler must be, at least with conventions set by [containerd](https://containerd.io/).

The paths to the containerized process executable binary are in our sample environment in the format:
```
/run/containerd/io.containerd.runtime.v2.task/k8s.io/${CONTAINER_ID}/rootfs/${PATH_FROM_PROC}
```